### PR TITLE
Removes f16 version because it needs a bigger context window

### DIFF
--- a/mistral nemo Instruct 2407.md
+++ b/mistral nemo Instruct 2407.md
@@ -22,7 +22,6 @@ Compared to Mistral 7B, it is much better at following precise instructions, rea
 
 | Model Variant                                                | Parameters | Quantization | Context Window | VRAM   | Size  |
 |--------------------------------------------------------------|------------|--------------|----------------|--------|-------|
-| `ai/mistral-nemo:12B-F16`                                    | 12B        | FP16         | 128k tokens    | 28GB¹  | 24 GB |
 | `ai/mistral-nemo:latest`<br><br>`ai/mistral-nemo:12B-Q4_K_M` | 12B        | Q4_K_M       | 128k tokens    | 7GB¹   | 7.1 GB|
 
 ¹: VRAM estimated based on model characteristics.


### PR DESCRIPTION
This pull request includes a change to the `mistral nemo Instruct 2407.md` file. The change updates the model variant information in the comparison table.

* Removed the `ai/mistral-nemo:12B-F16` model variant from the comparison table.