### PR TITLE
Fix: Update model cards, remove obsolete scripts, and adjust context metadata

### DIFF
--- a/gemma3-qat.md
+++ b/gemma3-qat.md
@@ -27,7 +27,7 @@ Gemma is a versatile AI model family designed for tasks like question answering,
 
 | Model Variant                                           | Parameters | Quantization   | Context Window | VRAM      | Size   | 
 |-------------------------------------------------------- |----------- |----------------|--------------- |---------- |------- |
-| `ai/gemma3-qat:1B-Q4_K_M`                               | 1B         | IQ2_XXS/Q4_K_M | 128K tokens    |  0.892GB¹ | 0.95GB |
+| `ai/gemma3-qat:1B-Q4_K_M`                               | 1B         | IQ2_XXS/Q4_K_M | 32K tokens     |  0.892GB¹ | 0.95GB |
 | `ai/gemma3-qat:latest`<br><br>`ai/gemma3-qat:4B-Q4_K_M` | 4B         | IQ2_XXS/Q4_K_M | 128K tokens    |  3.4GB¹   | 2.93GB |
 | `ai/gemma3-qat:12B-Q4_K_M`                              | 12B        | IQ2_XXS/Q4_K_M | 128K tokens    |  8.7GB¹   | 7.52GB |
 | `ai/gemma3-qat:27B-Q4_K_M`                              | 27B        | IQ2_XXS/Q4_K_M | 128K tokens    |  21GB¹    | 16GB   |

--- a/gemma3.md
+++ b/gemma3.md
@@ -21,8 +21,8 @@ Gemma is a versatile AI model family designed for tasks like question answering,
 
 | Model Variant                                   | Parameters | Quantization   | Context Window | VRAM      | Size   | 
 |-------------------------------------------------|----------- |----------------|--------------- |---------- |------- |
-| `ai/gemma3:1B-F16`                              | 1B         | F16            | 128K tokens    |  1.5GB¹   | 0.75GB |
-| `ai/gemma3:1B-Q4_K_M`                           | 1B         | IQ2_XXS/Q4_K_M | 128K tokens    |  0.892GB¹ | 1.87GB |
+| `ai/gemma3:1B-F16`                              | 1B         | F16            | 32K tokens     |  1.5GB¹   | 0.75GB |
+| `ai/gemma3:1B-Q4_K_M`                           | 1B         | IQ2_XXS/Q4_K_M | 32K tokens     |  0.892GB¹ | 1.87GB |
 | `ai/gemma3:4B-F16`                              | 4B         | F16            | 128K tokens    |  6.4GB¹   | 7.7GB  | 
 | `ai/gemma3:latest`<br><br>`ai/gemma3:4B-Q4_K_M` | 4B         | IQ2_XXS/Q4_K_M | 128K tokens    |  3.4GB¹   | 2.5GB  | 
 

--- a/llama3_1.md
+++ b/llama3_1.md
@@ -21,9 +21,8 @@
 
 | Model Variant                                        | Parameters | Quantization   | Context Window | VRAM      | Size   | 
 |----------------------------------------------------- |----------- |--------------- |--------------- |---------- |------- |
-| `ai/llama3.1:latest`<br><br>`ai/llama3.1:8B-Q4_K_M`  | 8B         | Q4_K_M         | 128K           | 4.8GB¹    | -      |
-| `ai/llama3.1:8B-F16`                                 | 8B         | F16            | 128K           | 19.2GB¹   | -      | 
-| `ai/llama3.1:70B-Q4_K_M`                             | 70B        | Q4_K_M         | 128K           | 42GB¹     | _      |
+| `ai/llama3.1:latest`<br><br>`ai/llama3.1:8B-Q4_K_M`  | 8B         | Q4_K_M         | 128K           | 4.8GB¹    | 5GB    |
+| `ai/llama3.1:8B-F16`                                 | 8B         | F16            | 128K           | 19.2GB¹   | 16GB   | 
 
 ¹: VRAM estimates based on model characteristics.
 

--- a/llama3_2.md
+++ b/llama3_2.md
@@ -22,9 +22,9 @@ Llama 3.2 introduced lightweight 1B and 3B models at bfloat16 (BF16) precision, 
 | Model Variant                                       | Parameters | Quantization | Context Window | VRAM   | Size  | 
 |---------------------------------------------------- |------------|--------------|----------------|--------|-------|
 | `ai/llama3.2:3B-F16`                                | 3B         | F16          | 128k tokens    | 7.2GB¹ | 6GB   |
-| `ai/llama3.2:latest`<br><br>`ai/llama3.2:3B-Q4_K_M` | 3B         | Q4_K_M       | 8K tokens      | 1.8GB¹ | 1.8GB | 
+| `ai/llama3.2:latest`<br><br>`ai/llama3.2:3B-Q4_K_M` | 3B         | Q4_K_M       | 128K tokens    | 1.8GB¹ | 1.8GB | 
 | `ai/llama3.2:1B-F16`                                | 1B         | F16          | 128K tokens    | 2.4GB¹ | 2.3GB |
-| `ai/llama3.2:1B-Q8_0`                               | 1B         | Q8_0         | 8K tokens      | 1.2GB¹ | 1.2GB | 
+| `ai/llama3.2:1B-Q8_0`                               | 1B         | Q8_0         | 128K tokens    | 1.2GB¹ | 1.2GB | 
 
 ¹: VRAM estimated based on model characteristics.
 

--- a/qwen2.5.md
+++ b/qwen2.5.md
@@ -20,15 +20,19 @@ Qwen2.5-7B-Instruct is an instruction-tuned large language model developed by Al
 
 ## Available Model Variants
 
-| Model Variant                        | Parameters | Quantization       | Context Window | VRAM      | Size    |                  
-|--------------------------------------|------------|--------------------|----------------|-----------|---------|
-| `ai/qwen2.5:7B-F16`                     | 7.61B      | F16                | 128k tokens    | 18GB¹     | 14.2GB  | 
-| `ai/qwen2.5:latest`<br><br>`ai/qwen2.5:7B-Q4_K_M` | 7.61B      | IQ2_XXS/Q4_K_MGGUF | 128k tokens    | 5GB¹      | 4.4GB   | 
+| Model Variant                                    | Parameters | Quantization     | Context Window | VRAM     | Size   |
+|--------------------------------------------------|------------|------------------|----------------|----------|--------|
+| `ai/qwen2.5:0.5B-F16`                            | 0.5B       | F16              | 32K tokens     | ~1.2GB¹  | 0.99GB |
+| `ai/qwen2.5:1.5B-F16`                            | 1.5B       | F16              | 32K tokens     | ~3.5GB¹  | 3.09GB |
+| `ai/qwen2.5:3B-F16`                              | 3.09B      | F16              | 32K tokens     | ~7GB¹    | 6.18GB |
+| `ai/qwen2.5:3B-Q4_K_M`                           | 3.09B      | IQ2_XXS/Q4_K_M   | 32K tokens     | ~2.2GB¹  | 1.93GB |
+| `ai/qwen2.5:7B-F16`                              | 7.62B      | F16              | 32K tokens     | ~16GB¹   | 15.24GB|
+| `ai/qwen2.5:7B-Q4_K_M`<br><br>`ai/qwen2.5:latest`| 7.62B      | IQ2_XXS/Q4_K_M   | 32K tokens     | ~4.7GB¹  | 4.68GB |
 
 ¹: VRAM estimates based on model characteristics.
 
 > `:latest`→ `7B-Q4_K_M`
-
+docker 
 ## Intended Uses
 
 Qwen2.5-7B-Instruct is designed to assist in various natural language processing tasks, including:

--- a/qwq.md
+++ b/qwq.md
@@ -23,8 +23,8 @@ The model incorporates agent-like capabilities, allowing it to perform critical 
 
 | Model Variant                              | Parameters | Quantization | Context Window | VRAM    | Size  | 
 |--------------------------------------------|------------|--------------|----------------|---------|-------|
-| `ai/qwq:32B-F16`                           | 32.5B      | FP16         | 32K tokens     | 77GB¹   | 65.5GB|
-| `ai/qwq:latest`<br><br>`ai/qwq:32B-Q4_K_M` | 32.5B      | Q4_K_M       | 32K tokens     | 19GB¹   | 18.8GB|
+| `ai/qwq:32B-F16`                           | 32.5B      | FP16         | 40K tokens     | 77GB¹   | 65.5GB|
+| `ai/qwq:latest`<br><br>`ai/qwq:32B-Q4_K_M` | 32.5B      | Q4_K_M       | 40K tokens     | 19GB¹   | 18.8GB|
 
 > `:latest` → `32B-Q4_K_M`
 


### PR DESCRIPTION
Fixed:
- Some model cards contained incorrect context window sizes (Gemma3-qat, Gemma3, Llama 3.1, Llama 3.2,...)
- `incept-oci.sh` is now `inspect-model.sh` and supports multiple licenses and deep inspection with `gguf-tools` with the `--verbose` flag.