### PR TITLE
Fix gemma3 model sizes

### DIFF
--- a/gemma3.md
+++ b/gemma3.md
@@ -32,10 +32,10 @@ Gemma 3 4B model can be used for:
 
 | Model Variant                                   | Parameters | Quantization   | Context Window | VRAM      | Size   | 
 |-------------------------------------------------|----------- |----------------|--------------- |---------- |------- |
-| `ai/gemma3:1B-F16`                              | 1B         | F16            | 32K tokens     |  1.5GB¹   | 0.75GB |
-| `ai/gemma3:1B-Q4_K_M`                           | 1B         | IQ2_XXS/Q4_K_M | 32K tokens     |  0.892GB¹ | 1.87GB |
-| `ai/gemma3:4B-F16`                              | 4B         | F16            | 128K tokens    |  6.4GB¹   | 7.7GB  | 
-| `ai/gemma3:latest`<br><br>`ai/gemma3:4B-Q4_K_M` | 4B         | IQ2_XXS/Q4_K_M | 128K tokens    |  3.4GB¹   | 2.5GB  | 
+| `ai/gemma3:1B-F16`                              | 1B         | F16            | 32K tokens     |  1.5GB¹   | 1.86GB |
+| `ai/gemma3:1B-Q4_K_M`                           | 1B         | IQ2_XXS/Q4_K_M | 32K tokens     |  0.892GB¹ | 0.76GB |
+| `ai/gemma3:4B-F16`                              | 4B         | F16            | 128K tokens    |  6.4GB¹   | 7.23GB | 
+| `ai/gemma3:latest`<br><br>`ai/gemma3:4B-Q4_K_M` | 4B         | IQ2_XXS/Q4_K_M | 128K tokens    |  3.4GB¹   | 2.31GB | 
 
 ¹: VRAM extracted from Gemma documentation ([link](https://ai.google.dev/gemma/docs/core#128k-context))
 


### PR DESCRIPTION
Adjusted with sizes reported by `docker model list`.  

Also apparently i had swapped the sizes for the 1b variants, so fixed that as well