### PR TITLE
Gemma 3 models don't support tool calling, and gemma3n don't support multimodal

### DIFF
--- a/ai/gemma3-qat.md
+++ b/ai/gemma3-qat.md
@@ -23,15 +23,15 @@ Gemma 3 4B model can be used for:
 
 ## Characteristics
 
-| Attribute             | Details        |
-|---------------------- |--------------- |
-| **Provider**          | Google DeepMind |
-| **Architecture**      | Gemma3         |
-| **Cutoff date**       | -              |
-| **Languages**         | 140 languages  |
-| **Tool calling**      | ❌              |
-| **Input modalities**  | Text, Image    |
-| **Output modalities** | Text, Code     |
+| Attribute             | Details                                          |
+|-----------------------|--------------------------------------------------|
+| **Provider**          | Google DeepMind                                  |
+| **Architecture**      | Gemma3                                           |
+| **Cutoff date**       | -                                                |
+| **Languages**         | 140 languages                                    |
+| **Tool calling**      | ❌                                                |
+| **Input modalities**  | Text, Image                                      |
+| **Output modalities** | Text, Code                                       |
 | **License**           | [Gemma Terms](https://ai.google.dev/gemma/terms) |
 
 ## Available model variants

--- a/ai/gemma3.md
+++ b/ai/gemma3.md
@@ -17,15 +17,15 @@ Gemma 3 4B model can be used for:
 
 ## Characteristics
 
-| Attribute             | Details        |
-|---------------------- |--------------- |
-| **Provider**          | Google DeepMind |
-| **Architecture**      | Gemma3         |
-| **Cutoff date**       | -              |
-| **Languages**         | 140 languages  |
-| **Tool calling**      | ❌              |
-| **Input modalities**  | Text, Image    |
-| **Output modalities** | Text, Code     |
+| Attribute             | Details                                          |
+|-----------------------|--------------------------------------------------|
+| **Provider**          | Google DeepMind                                  |
+| **Architecture**      | Gemma3                                           |
+| **Cutoff date**       | -                                                |
+| **Languages**         | 140 languages                                    |
+| **Tool calling**      | ❌                                                |
+| **Input modalities**  | Text, Image                                      |
+| **Output modalities** | Text, Code                                       |
 | **License**           | [Gemma Terms](https://ai.google.dev/gemma/terms) |
 
 ## Available model variants

--- a/ai/gemma3n.md
+++ b/ai/gemma3n.md
@@ -18,15 +18,15 @@ Gemma 3n models are designed for:
 
 ## Characteristics
 
-| Attribute             | Details                                        |
-|---------------------- |------------------------------------------------|
-| **Provider**          | Google DeepMind                                |
-| **Architecture**      | Gemma 3n                                       |
-| **Cutoff date**       | June 2024                                      |
-| **Languages**         | 140+                                           |
-| **Tool calling**      | ❌                                               |
-| **Input modalities**  | Text                      |
-| **Output modalities** | Text                                           |
+| Attribute             | Details                                          |
+|-----------------------|--------------------------------------------------|
+| **Provider**          | Google DeepMind                                  |
+| **Architecture**      | Gemma 3n                                         |
+| **Cutoff date**       | June 2024                                        |
+| **Languages**         | 140+                                             |
+| **Tool calling**      | ❌                                                |
+| **Input modalities**  | Text                                             |
+| **Output modalities** | Text                                             |
 | **License**           | [Gemma Terms](https://ai.google.dev/gemma/terms) |
 
 ## Available model variants


### PR DESCRIPTION
## Summary by Sourcery

Update documentation to reflect that Gemma 3, Gemma 3-qat, and Gemma 3n models no longer support tool calling, and restrict Gemma 3n to text-only input and output.

Documentation:
- Remove tool calling support from Gemma 3, Gemma 3-qat, and Gemma 3n model documentation
- Restrict Gemma 3n input and output modalities to text only