### PR TITLE
Add Granite models

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ Distilled LLaMA by DeepSeek, fast and optimized for real-world tasks.
 
 ---
 
+### Devstral Small 1.1
+![Mistral Logo](https://github.com/docker/model-cards/raw/refs/heads/main/logos/mistral-120x-hub@2x.svg)
+
+📌 **Description:**  
+Devstral Small 1.1 is an agentic coding LLM (24B) fine-tuned from Mistral-Small-3.1 with a 128K context window.
+
+📂 **Model File:** [`ai/devstral-small.md`](ai/devstral-small.md)  
+🐳 **Docker Hub:** [`docker.io/ai/devstral-small`](https://hub.docker.com/r/ai/devstral-small)
+
+---
+
 ### Gemma 3
 ![Gemma Logo](https://github.com/docker/model-cards/raw/refs/heads/main/logos/gemma-120x-hub@2x.svg)
 
@@ -92,6 +103,44 @@ Granite Embedding Multilingual is a 278 million parameter, encoder‑only XLM‑
 🐳 **Docker Hub:** [`docker.io/ai/granite-embedding-multilingual`](https://hub.docker.com/r/ai/granite-embedding-multilingual)
 
 ---
+
+### Granite 4.0 Micro
+![IBM Logo](https://github.com/docker/model-cards/raw/refs/heads/main/logos/ibm-120x-hub.svg)
+📌 **Description:**
+3B long-context instruct model with RL alignment, IF, tool use, and enterprise optimization.
+
+📂 **Model File:** [`ai/granite-4.0-micro.md`](ai/granite-4.0-micro.md)
+🐳 **Docker Hub:** [`docker.io/ai/granite-4.0-micro`](https://hub.docker.com/r/ai/granite-4.0-micro)
+
+---
+
+### Granite 4.0 H Micro
+![IBM Logo](https://github.com/docker/model-cards/raw/refs/heads/main/logos/ibm-120x-hub.svg)
+📌 **Description:**
+3B long-context instruct model with RL alignment, IF, tool calling, and enterprise readiness.
+
+📂 **Model File:** [`ai/granite-4.0-h-micro.md`](ai/granite-4.0-h-micro.md)
+🐳 **Docker Hub:** [`docker.io/ai/granite-4.0-h-micro`](https://hub.docker.com/r/ai/granite-4.0-h-micro)
+
+---
+
+### Granite 4.0 H Tiny
+![IBM Logo](https://github.com/docker/model-cards/raw/refs/heads/main/logos/ibm-120x-hub.svg)
+📌 **Description:**
+7B long-context instruct model with RL alignment, IF, tool use, and enterprise optimization.
+
+📂 **Model File:** [`ai/granite-4.0-h-tiny.md`](ai/granite-4.0-h-tiny.md)
+🐳 **Docker Hub:** [`docker.io/ai/granite-4.0-h-tiny`](https://hub.docker.com/r/ai/granite-4.0-h-tiny)
+
+---
+
+### Granite 4.0 H Small
+![IBM Logo](https://github.com/docker/model-cards/raw/refs/heads/main/logos/ibm-120x-hub.svg)
+📌 **Description:**
+32B long-context instruct model with RL alignment, IF, tool use, and enterprise optimization.
+
+📂 **Model File:** [`ai/granite-4.0-h-small.md`](ai/granite-4.0-h-small.md)
+🐳 **Docker Hub:** [`docker.io/ai/granite-4.0-h-small`](https://hub.docker.com/r/ai/granite-4.0-h-small)
 
 ### Llama 3.1
 ![Meta Logo](https://github.com/docker/model-cards/raw/refs/heads/main/logos/meta-120x-hub@2x.svg)
@@ -296,16 +345,6 @@ SmolLM3 is a 3.1B model for efficient on-device use, with strong performance in 
 📂 **Model File:** [`ai/smollm3.md`](ai/smollm3.md)  
 🐳 **Docker Hub:** [`docker.io/ai/smollm3`](https://hub.docker.com/r/ai/smollm3)
 
----
-
-### Devstral Small 1.1
-![Mistral Logo](https://github.com/docker/model-cards/raw/refs/heads/main/logos/mistral-120x-hub@2x.svg)
-
-📌 **Description:**  
-Devstral Small 1.1 is an agentic coding LLM (24B) fine-tuned from Mistral-Small-3.1 with a 128K context window.
-
-📂 **Model File:** [`ai/devstral-small.md`](ai/devstral-small.md)  
-🐳 **Docker Hub:** [`docker.io/ai/devstral-small`](https://hub.docker.com/r/ai/devstral-small)
 
 ## 🛠️ Tools
 

--- a/ai/granite-4.0-h-micro.md
+++ b/ai/granite-4.0-h-micro.md
@@ -1,0 +1,88 @@
+# Granite-4.0-h-Micro
+
+![logo](https://github.com/docker/model-cards/raw/refs/heads/main/logos/ibm-280x184-overview.svg)
+
+## Description
+Granite-4.0-H-Micro is a 3B parameter long-context instruct model finetuned from Granite-4.0-H-Micro-Base using a combination of open source instruction datasets with permissive license and internally collected synthetic datasets. This model is developed using a diverse set of techniques with a structured chat format, including supervised finetuning, model alignment using reinforcement learning, and model merging. Granite 4.0 instruct models feature improved instruction following (IF) and tool-calling capabilities, making them more effective in enterprise applications.
+
+## Characteristics
+
+| Attribute             | Details                                                                                                                           |
+|-----------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| **Provider**          | Granite Team, IBM                                                                                                                 |
+| **Architecture**      | granitehybrid                                                                                                                     |
+| **Cutoff date**       | Not disclosed                                                                                                                     |
+| **Languages**         | English, German, Spanish, French, Japanese, Portuguese, Arabic, Czech, Italian, Korean, Dutch, Chinese (extensible via finetuning) |
+| **Tool calling**      | ✅                                                                                                                                 |
+| **Input modalities**  | Text                                                                                                                              |
+| **Output modalities** | Text                                                                                                                              |
+| **License**           | Apache 2.0                                                                                                                        |
+
+## Available model variants
+
+| Model variant | Parameters | Quantization | Context window | VRAM¹ | Size |
+|---------------|------------|--------------|----------------|------|-------|
+| `ai/granite-4.0-h-micro:3B`<br><br>`ai/granite-4.0-h-micro:3B-Q4_K_M`<br><br>`ai/granite-4.0-h-micro:latest` | 3.2B | MOSTLY_Q4_K_M | 1M tokens | 2.32 GiB | 1.81 GB |
+
+¹: VRAM estimated based on model characteristics.
+
+> `latest` → `3B`
+
+## Use this AI model with Docker Model Runner
+
+```bash
+docker model run ai/granite-4.0-h-micro
+```
+
+## Considerations
+
+- Optimized for instruction following, tool/function calling, and long-context (up to 128K tokens) scenarios.
+- Strong generalist capabilities: summarization, classification, extraction, QA/RAG, coding, function-calling, and multilingual dialogue.
+- Multilingual: best performance in English; a few-shot approach or light finetuning can help close gaps for other languages.
+- Safety & reliability: despite alignment, the model can still produce inaccurate or biased outputs—apply domain-specific evaluation and guardrails.
+- Infrastructure note: trained on NVIDIA GB200 NVL72 at CoreWeave; use acceleration libraries (e.g., accelerate, optimized attention/KV cache settings) for efficient inference.
+
+## Benchmark performance
+
+| Category               | Metric                      | Granite-4.0-h-Micro |
+|------------------------|-----------------------------|---------------------|
+| **General Tasks**      |                             |                     |
+|                        | MMLU (5-shot)               | 67.43               |
+|                        | MMLU-Pro (5-shot, CoT)      | 43.48               |
+|                        | BBH (3-shot, CoT)           | 69.36               |
+|                        | AGI EVAL (0-shot, CoT)      | 59.00               |
+|                        | GPQA (0-shot, CoT)          | 32.15               |
+| **Alignment Tasks**    |                             |                     |
+|                        | AlpacaEval 2.0              | 31.49               |
+|                        | IFEval (Instruct, Strict)   | 86.94               |
+|                        | IFEval (Prompt, Strict)     | 81.71               |
+|                        | IFEval (Average)            | 84.32               |
+|                        | ArenaHard                   | 36.15               |
+| **Math Tasks**         |                             |                     |
+|                        | GSM8K (8-shot)              | 81.35               |
+|                        | GSM8K Symbolic (8-shot)     | 77.50               |
+|                        | Minerva Math (0-shot, CoT)  | 66.44               |
+|                        | DeepMind Math (0-shot, CoT) | 43.83               |
+| **Code Tasks**         |                             |                     |
+|                        | HumanEval (pass@1)          | 81.00               |
+|                        | HumanEval+ (pass@1)         | 75.00               |
+|                        | MBPP (pass@1)               | 73.00               |
+|                        | MBPP+ (pass@1)              | 64.00               |
+|                        | CRUXEval-O (pass@1)         | 41.25               |
+|                        | BigCodeBench (pass@1)       | 37.90               |
+| **Tool Calling Tasks** |                             |                     |
+|                        | BFCL v3                     | 57.56               |
+| **Multilingual Tasks** |                             |                     |
+|                        | MULTIPLE (pass@1)           | 49.46               |
+|                        | MMMLU (5-shot)              | 55.19               |
+|                        | INCLUDE (5-shot)            | 50.51               |
+|                        | MGSM (8-shot)               | 44.48               |
+| **Safety**             |                             |                     |
+|                        | SALAD-Bench                 | 96.28               |
+|                        | AttaQ                       | 84.44               |
+
+
+## Links
+- https://www.ibm.com/granite
+- https://www.ibm.com/granite/docs/
+- https://ibm.biz/granite-learning-resources

--- a/ai/granite-4.0-h-micro.md
+++ b/ai/granite-4.0-h-micro.md
@@ -1,4 +1,4 @@
-# Granite-4.0-h-Micro
+# Granite 4.0 H Micro
 
 ![logo](https://github.com/docker/model-cards/raw/refs/heads/main/logos/ibm-280x184-overview.svg)
 

--- a/ai/granite-4.0-h-small.md
+++ b/ai/granite-4.0-h-small.md
@@ -10,7 +10,7 @@ Granite-4.0-H-Small is a 32B parameter long-context instruct model finetuned fro
 | Attribute             | Details                                                                                                                            |
 |-----------------------|------------------------------------------------------------------------------------------------------------------------------------|
 | **Provider**          | Granite Team, IBM                                                                                                                  |
-| **Architecture**      | 	granitehybrid                                                                                                                     |
+| **Architecture**      | granitehybrid                                                                                                                     |
 | **Cutoff date**       | Not disclosed                                                                                                                      |
 | **Languages**         | English, German, Spanish, French, Japanese, Portuguese, Arabic, Czech, Italian, Korean, Dutch, Chinese (extensible via finetuning) |
 | **Tool calling**      | ✅                                                                                                                                  |

--- a/ai/granite-4.0-h-small.md
+++ b/ai/granite-4.0-h-small.md
@@ -1,0 +1,88 @@
+# Granite-4.0-h-Small
+
+![logo](https://github.com/docker/model-cards/raw/refs/heads/main/logos/ibm-280x184-overview.svg)
+
+## Description
+Granite-4.0-H-Small is a 32B parameter long-context instruct model finetuned from Granite-4.0-H-Small-Base using a combination of open source instruction datasets with permissive license and internally collected synthetic datasets. This model is developed using a diverse set of techniques with a structured chat format, including supervised finetuning, model alignment using reinforcement learning, and model merging. Granite 4.0 instruct models feature improved instruction following (IF) and tool-calling capabilities, making them more effective in enterprise applications.
+
+## Characteristics
+
+| Attribute             | Details                                                                                                                            |
+|-----------------------|------------------------------------------------------------------------------------------------------------------------------------|
+| **Provider**          | Granite Team, IBM                                                                                                                  |
+| **Architecture**      | 	granitehybrid                                                                                                                     |
+| **Cutoff date**       | Not disclosed                                                                                                                      |
+| **Languages**         | English, German, Spanish, French, Japanese, Portuguese, Arabic, Czech, Italian, Korean, Dutch, Chinese (extensible via finetuning) |
+| **Tool calling**      | ✅                                                                                                                                  |
+| **Input modalities**  | Text                                                                                                                               |
+| **Output modalities** | Text                                                                                                                               |
+| **License**           | Apache 2.0                                                                                                                         |
+
+## Available model variants
+
+| Model variant | Parameters | Quantization | Context window | VRAM¹ | Size |
+|---------------|------------|--------------|----------------|------|-------|
+| `ai/granite-4.0-h-small:32B`<br><br>`ai/granite-4.0-h-small:32B-Q4_K_M`<br><br>`ai/granite-4.0-h-small:latest` | 32.21 B | MOSTLY_Q4_K_M | 1M tokens | 18.80 GiB | 18.14 GB |
+
+¹: VRAM estimated based on model characteristics.
+
+> `latest` → `32B`
+
+## Use this AI model with Docker Model Runner
+
+```bash
+docker model run ai/granite-4.0-h-small
+```
+
+## Considerations
+
+- Optimized for instruction following, tool/function calling, and long-context (up to 128K tokens) scenarios.
+- Strong generalist capabilities: summarization, classification, extraction, QA/RAG, coding, function-calling, and multilingual dialogue.
+- Multilingual: best performance in English; a few-shot approach or light finetuning can help close gaps for other languages.
+- Safety & reliability: despite alignment, the model can still produce inaccurate or biased outputs—apply domain-specific evaluation and guardrails.
+- Infrastructure note: trained on NVIDIA GB200 NVL72 at CoreWeave; use acceleration libraries (e.g., accelerate, optimized attention/KV cache settings) for efficient inference.
+
+## Benchmark performance
+
+| Category               | Metric                      | Granite-4.0-h-Small |
+|------------------------|-----------------------------|---------------------|
+| **General Tasks**      |                             |                     |
+|                        | MMLU (5-shot)               | 78.44               |
+|                        | MMLU-Pro (5-shot, CoT)      | 55.47               |
+|                        | BBH (3-shot, CoT)           | 81.62               |
+|                        | AGI EVAL (0-shot, CoT)      | 70.63               |
+|                        | GPQA (0-shot, CoT)          | 40.63               |
+| **Alignment Tasks**    |                             |                     |
+|                        | AlpacaEval 2.0              | 42.48               |
+|                        | IFEval (Instruct, Strict)   | 89.87               |
+|                        | IFEval (Prompt, Strict)     | 85.22               |
+|                        | IFEval (Average)            | 87.55               |
+|                        | ArenaHard                   | 46.48               |
+| **Math Tasks**         |                             |                     |
+|                        | GSM8K (8-shot)              | 87.27               |
+|                        | GSM8K Symbolic (8-shot)     | 87.38               |
+|                        | Minerva Math (0-shot, CoT)  | 74.00               |
+|                        | DeepMind Math (0-shot, CoT) | 59.33               |
+| **Code Tasks**         |                             |                     |
+|                        | HumanEval (pass@1)          | 88.00               |
+|                        | HumanEval+ (pass@1)         | 83.00               |
+|                        | MBPP (pass@1)               | 84.00               |
+|                        | MBPP+ (pass@1)              | 71.00               |
+|                        | CRUXEval-O (pass@1)         | 50.25               |
+|                        | BigCodeBench (pass@1)       | 46.23               |
+| **Tool Calling Tasks** |                             |                     |
+|                        | BFCL v3                     | 64.69               |
+| **Multilingual Tasks** |                             |                     |
+|                        | MULTIPLE (pass@1)           | 57.37               |
+|                        | MMMLU (5-shot)              | 69.69               |
+|                        | INCLUDE (5-shot)            | 63.97               |
+|                        | MGSM (8-shot)               | 38.72               |
+| **Safety**             |                             |                     |
+|                        | SALAD-Bench                 | 97.30               |
+|                        | AttaQ                       | 86.64               |
+
+
+## Links
+- https://www.ibm.com/granite
+- https://www.ibm.com/granite/docs/
+- https://ibm.biz/granite-learning-resources

--- a/ai/granite-4.0-h-small.md
+++ b/ai/granite-4.0-h-small.md
@@ -1,4 +1,4 @@
-# Granite-4.0-h-Small
+# Granite 4.0 H Small
 
 ![logo](https://github.com/docker/model-cards/raw/refs/heads/main/logos/ibm-280x184-overview.svg)
 

--- a/ai/granite-4.0-h-tiny.md
+++ b/ai/granite-4.0-h-tiny.md
@@ -1,4 +1,4 @@
-# Granite-4.0-h-Tiny
+# Granite 4.0 H Tiny
 
 ![logo](https://github.com/docker/model-cards/raw/refs/heads/main/logos/ibm-280x184-overview.svg)
 

--- a/ai/granite-4.0-h-tiny.md
+++ b/ai/granite-4.0-h-tiny.md
@@ -1,0 +1,87 @@
+# Granite-4.0-h-Tiny
+
+![logo](https://github.com/docker/model-cards/raw/refs/heads/main/logos/ibm-280x184-overview.svg)
+
+## Description
+Granite-4.0-H-Tiny is a 7B parameter long-context instruct model finetuned from Granite-4.0-H-Tiny-Base using a combination of open source instruction datasets with permissive license and internally collected synthetic datasets. This model is developed using a diverse set of techniques with a structured chat format, including supervised finetuning, model alignment using reinforcement learning, and model merging. Granite 4.0 instruct models feature improved instruction following (IF) and tool-calling capabilities, making them more effective in enterprise applications.
+
+## Characteristics
+
+| Attribute             | Details                                                                                                                           |
+|-----------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| **Provider**          | Granite Team, IBM                                                                                                                 |
+| **Architecture**      | granitehybrid                                                                                                                     |
+| **Cutoff date**       | Not disclosed                                                                                                                     |
+| **Languages**         | English, German, Spanish, French, Japanese, Portuguese, Arabic, Czech, Italian, Korean, Dutch, Chinese (extensible via finetuning) |
+| **Tool calling**      | ✅                                                                                                                                 |
+| **Input modalities**  | Text                                                                                                                              |
+| **Output modalities** | Text                                                                                                                              |
+| **License**           | Apache 2.0                                                                                                                        |
+
+## Available model variants
+
+| Model variant | Parameters | Quantization | Context window | VRAM¹ | Size |
+|---------------|------------|--------------|----------------|------|-------|
+| `ai/granite-4.0-h-tiny:7B`<br><br>`ai/granite-4.0-h-tiny:7B-Q4_K_M`<br><br>`ai/granite-4.0-h-tiny:latest` | 64x994M | MOSTLY_Q4_K_M | 1M tokens | 4.41 GiB | 3.94 GB |
+
+¹: VRAM estimated based on model characteristics.
+
+> `latest` → `7B`
+
+## Use this AI model with Docker Model Runner
+
+```bash
+docker model run ai/granite-4.0-h-tiny
+```
+
+## Considerations
+
+- Optimized for instruction following, tool/function calling, and long-context (up to 128K tokens) scenarios.
+- Strong generalist capabilities: summarization, classification, extraction, QA/RAG, coding, function-calling, and multilingual dialogue.
+- Multilingual: best performance in English; a few-shot approach or light finetuning can help close gaps for other languages.
+- Safety & reliability: despite alignment, the model can still produce inaccurate or biased outputs—apply domain-specific evaluation and guardrails.
+- Infrastructure note: trained on NVIDIA GB200 NVL72 at CoreWeave; use acceleration libraries (e.g., accelerate, optimized attention/KV cache settings) for efficient inference.
+
+## Benchmark performance
+
+| Category               | Metric                      | Granite-4.0-h-Tiny |
+|------------------------|-----------------------------|--------------------|
+| **General Tasks**      |                             |                    |
+|                        | MMLU (5-shot)               | 68.65              |
+|                        | MMLU-Pro (5-shot, CoT)      | 44.94              |
+|                        | BBH (3-shot, CoT)           | 66.34              |
+|                        | AGI EVAL (0-shot, CoT)      | 62.15              |
+|                        | GPQA (0-shot, CoT)          | 32.59              |
+| **Alignment Tasks**    |                             |                    |
+|                        | AlpacaEval 2.0              | 30.61              |
+|                        | IFEval (Instruct, Strict)   | 84.78              |
+|                        | IFEval (Prompt, Strict)     | 78.10              |
+|                        | IFEval (Average)            | 81.44              |
+|                        | ArenaHard                   | 35.75              |
+| **Math Tasks**         |                             |                    |
+|                        | GSM8K (8-shot)              | 84.69              |
+|                        | GSM8K Symbolic (8-shot)     | 81.10              |
+|                        | Minerva Math (0-shot, CoT)  | 69.64              |
+|                        | DeepMind Math (0-shot, CoT) | 49.92              |
+| **Code Tasks**         |                             |                    |
+|                        | HumanEval (pass@1)          | 83.00              |
+|                        | HumanEval+ (pass@1)         | 76.00              |
+|                        | MBPP (pass@1)               | 80.00              |
+|                        | MBPP+ (pass@1)              | 69.00              |
+|                        | CRUXEval-O (pass@1)         | 39.63              |
+|                        | BigCodeBench (pass@1)       | 41.06              |
+| **Tool Calling Tasks** |                             |                    |
+|                        | BFCL v3                     | 57.65              |
+| **Multilingual Tasks** |                             |                    |
+|                        | MULTIPLE (pass@1)           | 55.83              |
+|                        | MMMLU (5-shot)              | 61.87              |
+|                        | INCLUDE (5-shot)            | 53.12              |
+|                        | MGSM (8-shot)               | 45.36              |
+| **Safety**             |                             |                    |
+|                        | SALAD-Bench                 | 97.77              |
+|                        | AttaQ                       | 86.61              |
+
+## Links
+- https://www.ibm.com/granite
+- https://www.ibm.com/granite/docs/
+- https://ibm.biz/granite-learning-resources

--- a/ai/granite-4.0-micro.md
+++ b/ai/granite-4.0-micro.md
@@ -1,4 +1,4 @@
-# Granite-4.0-Micro
+# Granite 4.0 Micro
 
 ![logo](https://github.com/docker/model-cards/raw/refs/heads/main/logos/ibm-280x184-overview.svg)
 

--- a/ai/granite-4.0-micro.md
+++ b/ai/granite-4.0-micro.md
@@ -37,7 +37,7 @@ docker model run ai/granite-4.0-micro
 ## Considerations
 
 - Optimized for instruction following, tool/function calling, and long-context (up to 128K tokens) scenarios.
-- Strong generalist capabilities: summarization, classification, extraction, QA/RAG, coding, function-calling, and multilingual dialogue. 
+- Strong generalist capabilities: summarization, classification, extraction, QA/RAG, coding, function-calling, and multilingual dialogue.
 - Multilingual: best performance in English; a few-shot approach or light finetuning can help close gaps for other languages.
 - Safety & reliability: despite alignment, the model can still produce inaccurate or biased outputs—apply domain-specific evaluation and guardrails.
 - Infrastructure note: trained on NVIDIA GB200 NVL72 at CoreWeave; use acceleration libraries (e.g., accelerate, optimized attention/KV cache settings) for efficient inference.

--- a/ai/granite-4.0-micro.md
+++ b/ai/granite-4.0-micro.md
@@ -1,0 +1,87 @@
+# Granite-4.0-Micro
+
+![logo](https://github.com/docker/model-cards/raw/refs/heads/main/logos/ibm-280x184-overview.svg)
+
+## Description
+Granite-4.0-Micro is a 3B parameter long-context instruct model finetuned from Granite-4.0-Micro-Base using a combination of open source instruction datasets with permissive license and internally collected synthetic datasets. This model is developed using a diverse set of techniques with a structured chat format, including supervised finetuning, model alignment using reinforcement learning, and model merging. Granite 4.0 instruct models feature improved instruction following (IF) and tool-calling capabilities, making them more effective in enterprise applications.
+
+## Characteristics
+
+| Attribute             | Details                                                                                                                           |
+|-----------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| **Provider**          | Granite Team, IBM                                                                                                                 |
+| **Architecture**      | granitehybrid                                                                                                                     |
+| **Cutoff date**       | Not disclosed                                                                                                                     |
+| **Languages**         | English, German, Spanish, French, Japanese, Portuguese, Arabic, Czech, Italian, Korean, Dutch, Chinese (extensible via finetuning) |
+| **Tool calling**      | ✅                                                                                                                                 |
+| **Input modalities**  | Text                                                                                                                              |
+| **Output modalities** | Text                                                                                                                              |
+| **License**           | Apache 2.0                                                                                                                        |
+
+## Available model variants
+
+| Model variant | Parameters | Quantization | Context window | VRAM¹ | Size |
+|---------------|------------|--------------|----------------|------|-------|
+| `ai/granite-4.0-micro:3B`<br><br>`ai/granite-4.0-micro:3B-Q4_K_M`<br><br>`ai/granite-4.0-micro:latest` | 3.2B | MOSTLY_Q4_K_M | 1M tokens | 2.32 GiB | 1.81 GB |
+
+¹: VRAM estimated based on model characteristics.
+
+> `latest` → `3B`
+
+## Use this AI model with Docker Model Runner
+
+```bash
+docker model run ai/granite-4.0-micro
+```
+
+## Considerations
+
+- Optimized for instruction following, tool/function calling, and long-context (up to 128K tokens) scenarios.
+- Strong generalist capabilities: summarization, classification, extraction, QA/RAG, coding, function-calling, and multilingual dialogue. 
+- Multilingual: best performance in English; a few-shot approach or light finetuning can help close gaps for other languages.
+- Safety & reliability: despite alignment, the model can still produce inaccurate or biased outputs—apply domain-specific evaluation and guardrails.
+- Infrastructure note: trained on NVIDIA GB200 NVL72 at CoreWeave; use acceleration libraries (e.g., accelerate, optimized attention/KV cache settings) for efficient inference.
+
+## Benchmark performance
+
+| Category               | Metric                      | Granite-4.0-Micro |
+|------------------------|-----------------------------|-------------------|
+| **General Tasks**      |                             |                   |
+|                        | MMLU (5-shot)               | 65.98             |
+|                        | MMLU-Pro (5-shot, CoT)      | 44.50             |
+|                        | BBH (3-shot, CoT)           | 72.48             |
+|                        | AGI EVAL (0-shot, CoT)      | 64.29             |
+|                        | GPQA (0-shot, CoT)          | 30.14             |
+| **Alignment Tasks**    |                             |                   |
+|                        | AlpacaEval 2.0              | 29.49             |
+|                        | IFEval (Instruct, Strict)   | 85.50             |
+|                        | IFEval (Prompt, Strict)     | 79.12             |
+|                        | IFEval (Average)            | 82.31             |
+|                        | ArenaHard                   | 25.84             |
+| **Math Tasks**         |                             |                   |
+|                        | GSM8K (8-shot)              | 85.45             |
+|                        | GSM8K Symbolic (8-shot)     | 79.82             |
+|                        | Minerva Math (0-shot, CoT)  | 62.06             |
+|                        | DeepMind Math (0-shot, CoT) | 44.56             |
+| **Code Tasks**         |                             |                   |
+|                        | HumanEval (pass@1)          | 80.00             |
+|                        | HumanEval+ (pass@1)         | 72.00             |
+|                        | MBPP (pass@1)               | 72.00             |
+|                        | MBPP+ (pass@1)              | 64.00             |
+|                        | CRUXEval-O (pass@1)         | 41.50             |
+|                        | BigCodeBench (pass@1)       | 39.21             |
+| **Tool Calling Tasks** |                             |                   |
+|                        | BFCL v3                     | 59.98             |
+| **Multilingual Tasks** |                             |                   |
+|                        | MULTIPLE (pass@1)           | 49.21             |
+|                        | MMMLU (5-shot)              | 55.14             |
+|                        | INCLUDE (5-shot)            | 51.62             |
+|                        | MGSM (8-shot)               | 28.56             |
+| **Safety**             |                             |                   |
+|                        | SALAD-Bench                 | 97.06             |
+|                        | AttaQ                       | 86.05             |
+
+## Links
+- https://www.ibm.com/granite
+- https://www.ibm.com/granite/docs/
+- https://ibm.biz/granite-learning-resources


### PR DESCRIPTION
This pull request updates the model catalog by adding detailed documentation and listings for new IBM Granite 4.0 models. Four new model cards are introduced for the Granite 4.0 family, each with comprehensive descriptions, benchmark results, and usage instructions. The `README.md` is updated to reflect these additions, and duplicate or misplaced entries are cleaned up.

## Summary by Sourcery

Introduce four new Granite 4.0 model cards and update the README to include them while cleaning up duplicate entries

New Features:
- Add IBM Granite 4.0 Micro, H-Micro, H-Tiny, and H-Small model cards with detailed descriptions, benchmarks, and usage instructions

Documentation:
- Add individual markdown files for each Granite 4.0 model variant under ai/ and update README to list the new models

Chores:
- Remove duplicated Devstral Small 1.1 entry in README